### PR TITLE
Refactor warmup parameter

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,18 +1,21 @@
 ---
 input_file: "data/util_data.csv"
-output_file: "output/cooldown_test.csv"
-metrics_output_file: "output/cooldown_test_metrics.csv"
+output_file: "output/simple_scaling_v2.csv"
+metrics_output_file: "output/simple_scaling_v2_metrics.csv"
 metrics: False
 initial_allocated_cores:
 process_data_func: 'process_util_data'
 time: # TODO application
   granularity: 60
-  boot: 1 
   warm_up:
-    min: 9
-    max: 12
+    boot:
+      min: 1
+      max: 3
+    startup:
+      min: 6
+      max: 9
 policies:
-  use: "target_tracking" # TODO tirar use de policies
+  use: "simple_scaling" # TODO tirar use de policies
   simple_scaling:
     src: "src/policies/simple_scaling_policy.R"
     func: "simple_scaling_policy"

--- a/src/auto_scaling_algorithm.R
+++ b/src/auto_scaling_algorithm.R
@@ -2,6 +2,7 @@
 auto_scaling_algorithm <- function(data, initial_allocated_cores,
                                    policy_parameters, time_parameters){
   cores_allocated <- initial_allocated_cores
+  warm_up <- time_parameters$warm_up
   
   cooldown <- get_cooldown(policy_parameters$cooldown)
   
@@ -86,14 +87,10 @@ auto_scaling_algorithm <- function(data, initial_allocated_cores,
         #   - they will have to wait for boot and warm-up times.
         #   - the cooldown period will start only after the boot time.
         
-        warmup_time <- round(runif(
-          1,
-          time_parameters$warm_up$min,
-          time_parameters$warm_up$max
-        ))
-        
-        cooldown_up_start <- current_time + time_parameters$boot * 60
-        adding_time <- c(adding_time, cooldown_up_start + warmup_time * 60)
+        startup <- get_random_time(warm_up$startup)
+        boot <- get_random_time(warm_up$boot)
+        cooldown_up_start <- current_time + boot * 60 + startup * 60
+        adding_time <- c(adding_time, cooldown_up_start)
         adding_cores <- c(adding_cores, cores)
       }
       
@@ -143,4 +140,14 @@ get_cooldown <- function(cooldown_param) {
   )
   
   return (cooldown)
+}
+
+get_random_time <- function(time_parameter) {
+  random_time <- round(runif(
+    1,
+    time_parameter$min,
+    time_parameter$max
+  ))
+
+  return (random_time)
 }


### PR DESCRIPTION
A pedido de @fabiomorais foi alterado o parâmetro de warmup para que o tempo de boot também seja aleatório e o startup também faça parte do warmup. Também está de acordo com a revisão de Fubica durante o seminário do PIBIC.